### PR TITLE
Add SeeAlso component, define shape.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ return (
 
 | Prop      | Type                                                      | Default | Required           |
 | --------- | --------------------------------------------------------- | ------- | ------------------ |
-| `as`      | ` ol`, `li`                                               | `ol`    | --                 |
+| `as`      | ` ol`, `ul`                                               | `ul`    | --                 |
+
 | `seeAlso` | [See IIIF](https://iiif.io/api/presentation/3.0/#seealso) | --      | :white_check_mark: |
 
 ```jsx

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ ReactJS UI component library of IIIF Presentation API 3.0 property fluent primit
 
 ---
 
+## Documentation
+
+- [Installation](#installation)
+- [Basic Usage](#basic-usage)
+- [Primitives](#primitives)
+  - [Label](#label)
+  - [Summary](#summary)
+  - [Required Statement](#required-statement)
+  - [Metadata](#metadata)
+  - [SeeAlso](#seealso)
+
+---
+
 <h2 id="installation">Installation</h2>
 
 Install the component from your command line using `npm install`,
@@ -68,7 +81,7 @@ The value of `lang` will couple with [InternationalString](https://github.com/II
 | Prop    | Type                                                                  | Default | Required           |
 | ------- | --------------------------------------------------------------------- | ------- | ------------------ |
 | `as`    | ` span`, `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `p`, `label`, `dt`, `dd` | `span`  | --                 |
-| `label` | `InternationalString`                                                 | --      | :white_check_mark: |
+| `label` | [See IIIF](https://iiif.io/api/presentation/3.0/#label)               | --      | :white_check_mark: |
 
 #### Usage
 
@@ -84,10 +97,10 @@ return <Label label={manifest.label} as="h1" lang="en" />;
 
 #### Reference
 
-| Prop      | Type                                             | Default | Required           |
-| --------- | ------------------------------------------------ | ------- | ------------------ |
-| `as`      | ` span`, `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `p` | `span`  | --                 |
-| `summary` | `InternationalString`                            | --      | :white_check_mark: |
+| Prop      | Type                                                      | Default | Required           |
+| --------- | --------------------------------------------------------- | ------- | ------------------ |
+| `as`      | ` span`, `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `p`          | `span`  | --                 |
+| `summary` | [See IIIF](https://iiif.io/api/presentation/3.0/#summary) | --      | :white_check_mark: |
 
 #### Usage
 
@@ -139,4 +152,21 @@ return (
     <figure>...</figure>
   </Homepage>
 );
+```
+
+### SeeAlso
+
+#### Reference
+
+| Prop      | Type                                                      | Default | Required           |
+| --------- | --------------------------------------------------------- | ------- | ------------------ |
+| `as`      | ` ol`, `li`                                               | `ol`    | --                 |
+| `seeAlso` | [See IIIF](https://iiif.io/api/presentation/3.0/#seealso) | --      | :white_check_mark: |
+
+```jsx
+import { SeeAlso } from "@samvera/nectar-iiif";
+```
+
+```jsx
+return <SeeAlso seeAlso={manifest.seeAlso} as="li" />;
 ```

--- a/src/components/SeeAlso/SeeAlso.tsx
+++ b/src/components/SeeAlso/SeeAlso.tsx
@@ -20,7 +20,6 @@ const SeeAlso: React.FC<NectarSeeAlso> = (props) => {
     <StyledWrapper as={as}>
       {seeAlso &&
         seeAlso.map((resource) => {
-          console.log(resource);
           const label = useGetLabel(resource.label, attributes.lang) as string;
           return (
             <StyledSeeAlso key={resource.id}>

--- a/src/components/SeeAlso/SeeAlso.tsx
+++ b/src/components/SeeAlso/SeeAlso.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { styled } from "stitches";
+import { useGetLabel } from "hooks/useGetLabel";
+import { NectarSeeAlso } from "types/nectar";
+import sanitizeAttributes from "services/html-element";
+
+const StyledSeeAlso = styled("li", {});
+const StyledWrapper = styled("ul", {});
+
+const SeeAlso: React.FC<NectarSeeAlso> = (props) => {
+  const { as, seeAlso } = props;
+
+  /**
+   * Create attributes and remove React props
+   */
+  const remove = ["as", "seeAlso"];
+  const attributes = sanitizeAttributes(props, remove);
+
+  return (
+    <StyledWrapper as={as}>
+      {seeAlso &&
+        seeAlso.map((resource) => {
+          const label = useGetLabel(resource.label, attributes.lang) as string;
+          return (
+            <StyledSeeAlso key={resource.id}>
+              <a href={resource.id} {...attributes}>
+                {label}
+              </a>
+            </StyledSeeAlso>
+          );
+        })}
+    </StyledWrapper>
+  );
+};
+
+export default SeeAlso;

--- a/src/components/SeeAlso/SeeAlso.tsx
+++ b/src/components/SeeAlso/SeeAlso.tsx
@@ -20,11 +20,12 @@ const SeeAlso: React.FC<NectarSeeAlso> = (props) => {
     <StyledWrapper as={as}>
       {seeAlso &&
         seeAlso.map((resource) => {
+          console.log(resource);
           const label = useGetLabel(resource.label, attributes.lang) as string;
           return (
             <StyledSeeAlso key={resource.id}>
               <a href={resource.id} {...attributes}>
-                {label}
+                {label ? label : resource.id}
               </a>
             </StyledSeeAlso>
           );

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -16,6 +16,7 @@ import { manifests } from "./dev/manifests";
 
 const Wrapper = () => {
   const defaultUrl: string = manifests[0].url;
+  const [seeAlso, setSeeAlso] = useState();
   const [thumbnail, setThumbnail] = useState();
   const [homepage, setHomepage] = useState();
   const [manifest, setManifest] = useState<ManifestNormalized>();
@@ -31,6 +32,7 @@ const Wrapper = () => {
           setManifest(data);
           setThumbnail(vault.get(data.thumbnail));
           setHomepage(vault.get(data.homepage));
+          setSeeAlso(vault.get(data.seeAlso));
         })
         .catch((error) => {
           console.error(`Manifest ${url} failed to load: ${error}`);
@@ -42,7 +44,7 @@ const Wrapper = () => {
   const handleLanguage = (e) =>
     setLanguage(e.target.value !== "--" ? e.target.value : undefined);
 
-  const { label, metadata, requiredStatement, seeAlso, summary } = manifest;
+  const { label, metadata, requiredStatement, summary } = manifest;
 
   return (
     <>
@@ -53,7 +55,7 @@ const Wrapper = () => {
         <Metadata metadata={metadata} lang={lang} />
         <RequiredStatement requiredStatement={requiredStatement} lang={lang} />
         {thumbnail && <Thumbnail thumbnail={thumbnail} alt="random" />}
-        <SeeAlso seeAlso={seeAlso} lang={lang} />
+        <SeeAlso seeAlso={seeAlso} />
       </div>
       <DynamicUrl url={url} setUrl={setUrl} handleLanguage={handleLanguage} />
     </>

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -1,6 +1,6 @@
 import React, { StrictMode, useEffect, useState } from "react";
 import { Vault } from "@iiif/vault";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 import { ManifestNormalized } from "@iiif/presentation-3";
 import {
   Homepage,
@@ -62,9 +62,11 @@ const Wrapper = () => {
   );
 };
 
-ReactDOM.render(
+const container = document.getElementById("root");
+const root = createRoot(container);
+
+root.render(
   <StrictMode>
     <Wrapper />
-  </StrictMode>,
-  document.getElementById("root")
+  </StrictMode>
 );

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -7,6 +7,7 @@ import {
   Label,
   Metadata,
   RequiredStatement,
+  SeeAlso,
   Summary,
   Thumbnail,
 } from "./index";
@@ -41,7 +42,7 @@ const Wrapper = () => {
   const handleLanguage = (e) =>
     setLanguage(e.target.value !== "--" ? e.target.value : undefined);
 
-  const { label, summary, metadata, requiredStatement } = manifest;
+  const { label, metadata, requiredStatement, seeAlso, summary } = manifest;
 
   return (
     <>
@@ -52,6 +53,7 @@ const Wrapper = () => {
         <Metadata metadata={metadata} lang={lang} />
         <RequiredStatement requiredStatement={requiredStatement} lang={lang} />
         {thumbnail && <Thumbnail thumbnail={thumbnail} alt="random" />}
+        <SeeAlso seeAlso={seeAlso} lang={lang} />
       </div>
       <DynamicUrl url={url} setUrl={setUrl} handleLanguage={handleLanguage} />
     </>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import Homepage from "components/Homepage/Homepage";
 import Label from "components/Label/Label";
 import Metadata from "components/Metadata/Metadata";
 import RequiredStatement from "components/RequiredStatement/RequiredStatement";
+import SeeAlso from "components/SeeAlso/SeeAlso";
 import Summary from "components/Summary/Summary";
 import Thumbnail from "components/Thumbnail/Thumbnail";
 import Value from "components/Value/Value";
@@ -11,6 +12,7 @@ export {
   Label,
   Metadata,
   RequiredStatement,
+  SeeAlso,
   Summary,
   Thumbnail,
   Value,

--- a/src/types/nectar.ts
+++ b/src/types/nectar.ts
@@ -25,6 +25,7 @@ export interface NectarExternalWebResource {
   duration?: number;
   width?: number;
   height?: number;
+  profle?: string;
 }
 
 export interface NectarHomepage extends NectarPrimitive {
@@ -59,14 +60,18 @@ export interface NectarRequiredStatement extends NectarPrimitive {
   requiredStatement: MetadataItem;
 }
 
-export interface NectarThumbnail extends NectarPrimitive {
-  altAsLabel?: InternationalString;
-  thumbnail: IIIFExternalWebResource[];
+export interface NectarSeeAlso extends NectarPrimitive {
+  as?: "ol" | "ul";
+  seeAlso: NectarExternalWebResource[];
 }
 
 export interface NectarSummary extends NectarPrimitive {
   as?: "span" | "p" | "label" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   summary: InternationalString;
+}
+export interface NectarThumbnail extends NectarPrimitive {
+  altAsLabel?: InternationalString;
+  thumbnail: IIIFExternalWebResource[];
 }
 
 export interface NectarValue extends NectarPrimitive {


### PR DESCRIPTION
## What does this do?

This adds a `<SeeAlso>` component that renders out entries of **seeAlso** as either an  `<ol>` or `<ul>`. The default `as` value is  `li`. Presentation 2 manifests not having a label will render the `id` as text content.


With this, the following Presentation 3.0 **seeAlso** would render as:

 - [Bibliographic Description in XML](https://example.org/library/catalog/book1.xml")
 - [Bibliographic Description in XML (related)](https://example.org/library/catalog/book2.xml")

```js
[
  {
    id: "https://example.org/library/catalog/book1.xml",
    type: "Dataset",
    label: { en: ["Bibliographic Description in XML"] },
    format: "text/xml",
    profile: "https://example.org/profiles/bibliographic",
  },
  {
    id: "https://example.org/library/catalog/book2.xml",
    type: "Dataset",
    label: { en: ["Bibliographic Description in XML (related)"] },
    format: "text/xml",
    profile: "https://example.org/profiles/bibliographic",
  },
]
```

## Review

- `npm run dev`
- View varying manifests with seeAlso from dev examples. Both version 2 and 3.0 manifests should render.