### PR TITLE
Support HTML markup rendering for summary and values.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@stitches/react": "^1.2.7",
+        "dompurify": "^2.3.8",
         "hls.js": "^1.1.5",
         "react": "^16.8  || ^17.0 || ^18.0",
         "react-dom": "^16.8  || ^17.0 || ^18.0"
@@ -19,6 +20,7 @@
         "@iiif/vault": "^0.9.17",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.1.1",
+        "@types/dompurify": "^2.3.3",
         "@types/jest": "^27.4.1",
         "@types/react": "^18.0.5",
         "@types/react-dom": "^18.0.1",
@@ -1215,6 +1217,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.3.3.tgz",
+      "integrity": "sha512-nnVQSgRVuZ/843oAfhA25eRSNzUFcBPk/LOiw5gm8mD9/X7CNcbRkQu/OsjCewO8+VIYfPxUnXvPEVGenw14+w==",
+      "dev": true,
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.8",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
@@ -1322,6 +1333,12 @@
       "dependencies": {
         "@types/jest": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
@@ -2420,6 +2437,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.8.tgz",
+      "integrity": "sha512-eVhaWoVibIzqdGYjwsBWodIQIaXFSB+cKDf4cfxLMsK0xiud6SE+/WCVx/Xw/UwQsa4cS3T2eITcdtmTg2UKcw=="
     },
     "node_modules/dotenv": {
       "version": "10.0.0",
@@ -8992,6 +9014,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/dompurify": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-2.3.3.tgz",
+      "integrity": "sha512-nnVQSgRVuZ/843oAfhA25eRSNzUFcBPk/LOiw5gm8mD9/X7CNcbRkQu/OsjCewO8+VIYfPxUnXvPEVGenw14+w==",
+      "dev": true,
+      "requires": {
+        "@types/trusted-types": "*"
+      }
+    },
     "@types/geojson": {
       "version": "7946.0.8",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
@@ -9099,6 +9130,12 @@
       "requires": {
         "@types/jest": "*"
       }
+    },
+    "@types/trusted-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
+      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "16.0.4",
@@ -9949,6 +9986,11 @@
           "dev": true
         }
       }
+    },
+    "dompurify": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.8.tgz",
+      "integrity": "sha512-eVhaWoVibIzqdGYjwsBWodIQIaXFSB+cKDf4cfxLMsK0xiud6SE+/WCVx/Xw/UwQsa4cS3T2eITcdtmTg2UKcw=="
     },
     "dotenv": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@iiif/vault": "^0.9.17",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.1.1",
+    "@types/dompurify": "^2.3.3",
     "@types/jest": "^27.4.1",
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.1",
@@ -51,6 +52,7 @@
   },
   "dependencies": {
     "@stitches/react": "^1.2.7",
+    "dompurify": "^2.3.8",
     "hls.js": "^1.1.5",
     "react": "^16.8  || ^17.0 || ^18.0",
     "react-dom": "^16.8  || ^17.0 || ^18.0"

--- a/src/components/ContentResource/ContentResources.tsx
+++ b/src/components/ContentResource/ContentResources.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from "react";
 import { styled } from "stitches";
 import Hls from "hls.js";
 import { useGetImageResource } from "hooks/useGetImageResource";
-import sanitizeAttributes from "services/html-element";
+import { sanitizeAttributes } from "services/html-element";
 import { useGetLabel } from "hooks/useGetLabel";
 import { NectarContentResource } from "types/nectar";
 

--- a/src/components/Homepage/Homepage.tsx
+++ b/src/components/Homepage/Homepage.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { styled } from "stitches";
 import { useGetLabel } from "hooks/useGetLabel";
 import { NectarHomepage } from "types/nectar";
-import sanitizeAttributes from "services/html-element";
+import { sanitizeAttributes } from "services/html-element";
 
 const StyledHomepage = styled("a", {});
 

--- a/src/components/Label/Label.test.tsx
+++ b/src/components/Label/Label.test.tsx
@@ -14,8 +14,12 @@ const multipleValueLabel = {
 
 const htmlWithinLabel = {
   none: [
-    `<a href="https://en.wikipedia.org/wiki/Honey"><strong>Honey</strong></a>`,
+    `<a href="https://en.wikipedia.org/wiki/Honey"><strong>&mdash;Honey&mdash;</strong></a>`,
   ],
+};
+
+const disallowedHtmlWithinLabel = {
+  none: [`<div style="color: gold;">the color of honey</a>`],
 };
 
 describe("label primitive", () => {
@@ -71,9 +75,18 @@ describe("label primitive", () => {
    * test rendering of html
    */
   it("Renders 3.0 HTML within a label", async () => {
-    const { getByRole } = render(<Label label={htmlWithinLabel} lang="en" />);
+    const { getByRole } = render(<Label label={htmlWithinLabel} />);
     const el = getByRole("link");
     expect(el.getAttribute("href")).toBe("https://en.wikipedia.org/wiki/Honey");
-    expect(el).toContainHTML("<strong>Honey</strong>");
+    expect(el).toContainHTML("<strong>—Honey—</strong>");
+  });
+
+  /**
+   * test sanitization of html
+   */
+  it("Renders 3.0 HTML within a label", async () => {
+    const { getByText } = render(<Label label={disallowedHtmlWithinLabel} />);
+    const el = getByText("the color of honey");
+    expect(el).toContainHTML("the color of honey");
   });
 });

--- a/src/components/Label/Label.test.tsx
+++ b/src/components/Label/Label.test.tsx
@@ -12,6 +12,12 @@ const multipleValueLabel = {
   none: ["the", "color", "of", "honey"],
 };
 
+const htmlWithinLabel = {
+  none: [
+    `<a href="https://en.wikipedia.org/wiki/Honey"><strong>Honey</strong></a>`,
+  ],
+};
+
 describe("label primitive", () => {
   /**
    * test internationalization and element assignment
@@ -59,5 +65,15 @@ describe("label primitive", () => {
     const el = getByRole("heading", { level: 5 });
     expect(el).toBeInTheDocument();
     expect(el).toHaveTextContent("the, color, of, honey");
+  });
+
+  /**
+   * test rendering of html
+   */
+  it("Renders 3.0 HTML within a label", async () => {
+    const { getByRole } = render(<Label label={htmlWithinLabel} lang="en" />);
+    const el = getByRole("link");
+    expect(el.getAttribute("href")).toBe("https://en.wikipedia.org/wiki/Honey");
+    expect(el).toContainHTML("<strong>Honey</strong>");
   });
 });

--- a/src/components/Label/Label.test.tsx
+++ b/src/components/Label/Label.test.tsx
@@ -12,16 +12,6 @@ const multipleValueLabel = {
   none: ["the", "color", "of", "honey"],
 };
 
-const htmlWithinLabel = {
-  none: [
-    `<a href="https://en.wikipedia.org/wiki/Honey"><strong>&mdash;Honey&mdash;</strong></a>`,
-  ],
-};
-
-const disallowedHtmlWithinLabel = {
-  none: [`<div style="color: gold;">the color of honey</a>`],
-};
-
 describe("label primitive", () => {
   /**
    * test internationalization and element assignment
@@ -69,24 +59,5 @@ describe("label primitive", () => {
     const el = getByRole("heading", { level: 5 });
     expect(el).toBeInTheDocument();
     expect(el).toHaveTextContent("the, color, of, honey");
-  });
-
-  /**
-   * test rendering of html
-   */
-  it("Renders 3.0 HTML within a label", async () => {
-    const { getByRole } = render(<Label label={htmlWithinLabel} />);
-    const el = getByRole("link");
-    expect(el.getAttribute("href")).toBe("https://en.wikipedia.org/wiki/Honey");
-    expect(el).toContainHTML("<strong>—Honey—</strong>");
-  });
-
-  /**
-   * test sanitization of html
-   */
-  it("Renders 3.0 HTML within a label", async () => {
-    const { getByText } = render(<Label label={disallowedHtmlWithinLabel} />);
-    const el = getByText("the color of honey");
-    expect(el).toContainHTML("the color of honey");
   });
 });

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { styled } from "stitches";
 import { useGetLabel } from "hooks/useGetLabel";
 import { NectarLabel } from "types/nectar";
-import { createMarkup, sanitizeAttributes } from "services/html-element";
+import { sanitizeAttributes } from "services/html-element";
 
 const StyledLabel = styled("span", {});
 
@@ -15,11 +15,11 @@ const Label: React.FC<NectarLabel> = (props) => {
   const remove = ["as", "label"];
   let attributes = sanitizeAttributes(props, remove);
 
-  const html = createMarkup(
-    useGetLabel(label, attributes.lang as string) as string
+  return (
+    <StyledLabel as={as} {...attributes}>
+      {useGetLabel(label, attributes.lang as string) as string}
+    </StyledLabel>
   );
-
-  return <StyledLabel as={as} {...attributes} dangerouslySetInnerHTML={html} />;
 };
 
 export default Label;

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { styled } from "stitches";
 import { useGetLabel } from "hooks/useGetLabel";
 import { NectarLabel } from "types/nectar";
-import sanitizeAttributes from "services/html-element";
+import { createMarkup, sanitizeAttributes } from "services/html-element";
 
 const StyledLabel = styled("span", {});
 
@@ -15,11 +15,11 @@ const Label: React.FC<NectarLabel> = (props) => {
   const remove = ["as", "label"];
   let attributes = sanitizeAttributes(props, remove);
 
-  return (
-    <StyledLabel as={as} {...attributes}>
-      {useGetLabel(label, attributes.lang as string)}
-    </StyledLabel>
+  const html = createMarkup(
+    useGetLabel(label, attributes.lang as string) as string
   );
+
+  return <StyledLabel as={as} {...attributes} dangerouslySetInnerHTML={html} />;
 };
 
 export default Label;

--- a/src/components/Markup/Markup.test.tsx
+++ b/src/components/Markup/Markup.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import Markup from "./Markup";
+
+const htmlWithinLabel = {
+  none: [
+    `<a href="https://en.wikipedia.org/wiki/Honey"><strong>&mdash;Honey&mdash;</strong></a>`,
+  ],
+};
+
+const disallowedHtmlWithinLabel = {
+  none: [`<div style="color: gold;">the color of honey</a>`],
+};
+
+describe("markup and sanitization", () => {
+  /**
+   * test rendering of html
+   */
+  it("Renders 3.0 HTML within a label", async () => {
+    const { getByRole } = render(<Markup markup={htmlWithinLabel} />);
+    const el = getByRole("link");
+    expect(el.getAttribute("href")).toBe("https://en.wikipedia.org/wiki/Honey");
+    expect(el).toContainHTML("<strong>—Honey—</strong>");
+  });
+
+  /**
+   * test sanitization of html
+   */
+  it("Renders 3.0 HTML within markup", async () => {
+    const { getByText } = render(<Markup markup={disallowedHtmlWithinLabel} />);
+    const el = getByText("the color of honey");
+    expect(el).toContainHTML("the color of honey");
+  });
+});

--- a/src/components/Markup/Markup.test.tsx
+++ b/src/components/Markup/Markup.test.tsx
@@ -16,7 +16,7 @@ describe("markup and sanitization", () => {
   /**
    * test rendering of html
    */
-  it("Renders 3.0 HTML within a label", async () => {
+  it("Tests rendering of HTML for markup.", async () => {
     const { getByRole } = render(<Markup markup={htmlWithinLabel} />);
     const el = getByRole("link");
     expect(el.getAttribute("href")).toBe("https://en.wikipedia.org/wiki/Honey");
@@ -26,7 +26,7 @@ describe("markup and sanitization", () => {
   /**
    * test sanitization of html
    */
-  it("Renders 3.0 HTML within markup", async () => {
+  it("Tests sanitizations of HTML within for markup.", async () => {
     const { getByText } = render(<Markup markup={disallowedHtmlWithinLabel} />);
     const el = getByText("the color of honey");
     expect(el).toContainHTML("the color of honey");

--- a/src/components/Markup/Markup.tsx
+++ b/src/components/Markup/Markup.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { styled } from "stitches";
+import { useGetLabel } from "hooks/useGetLabel";
+import { NectarMarkup } from "types/nectar";
+import { createMarkup, sanitizeAttributes } from "services/html-element";
+
+const StyledMarkup = styled("span", {});
+
+const Markup: React.FC<NectarMarkup> = (props) => {
+  const { as, markup } = props;
+
+  if (!markup) return <></>;
+
+  /**
+   * Create attributes and remove React props
+   */
+  const remove = ["as", "markup"];
+  let attributes = sanitizeAttributes(props, remove);
+
+  const html = createMarkup(
+    useGetLabel(markup, attributes.lang as string) as string
+  );
+
+  return (
+    <StyledMarkup as={as} {...attributes} dangerouslySetInnerHTML={html} />
+  );
+};
+
+export default Markup;

--- a/src/components/Metadata/Item.test.tsx
+++ b/src/components/Metadata/Item.test.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import Item from "./Item";
+
+const htmlWithinMetadataItem = {
+  label: { none: ["Type"] },
+  value: {
+    none: [
+      `<a href="https://en.wikipedia.org/wiki/Honey"><strong>Honey</strong></a>`,
+    ],
+  },
+};
+
+const htmlWithinLabel = {
+  label: {
+    none: [
+      `<a href="https://en.wikipedia.org/wiki/Type"><strong>Type</strong></a>`,
+    ],
+  },
+  value: {
+    none: [`Honey`],
+  },
+};
+
+describe("metadata primitive (item)", () => {
+  /**
+   * test rendering of html in metadata value
+   */
+  it("Renders 3.0 HTML within a label", async () => {
+    const { getByRole } = render(<Item item={htmlWithinMetadataItem} />);
+    const el = getByRole("link");
+    expect(el.getAttribute("href")).toBe("https://en.wikipedia.org/wiki/Honey");
+    expect(el).toContainHTML("<strong>Honey</strong>");
+  });
+
+  /**
+   * test rendering not rendering HTML markup for label
+   */
+  it("Renders 3.0 HTML within a label", async () => {
+    render(<Item item={htmlWithinLabel} />);
+    const el = screen.queryByText("Type");
+    expect(el).toBeNull;
+  });
+});

--- a/src/components/Metadata/Item.test.tsx
+++ b/src/components/Metadata/Item.test.tsx
@@ -26,7 +26,7 @@ describe("metadata primitive (item)", () => {
   /**
    * test rendering of html in metadata value
    */
-  it("Renders 3.0 HTML within a label", async () => {
+  it("Test rendering of html in metadata value", async () => {
     const { getByRole } = render(<Item item={htmlWithinMetadataItem} />);
     const el = getByRole("link");
     expect(el.getAttribute("href")).toBe("https://en.wikipedia.org/wiki/Honey");
@@ -36,7 +36,7 @@ describe("metadata primitive (item)", () => {
   /**
    * test rendering not rendering HTML markup for label
    */
-  it("Renders 3.0 HTML within a label", async () => {
+  it("Test rendering not rendering HTML markup for label", async () => {
     render(<Item item={htmlWithinLabel} />);
     const el = screen.queryByText("Type");
     expect(el).toBeNull;

--- a/src/components/Metadata/Metadata.tsx
+++ b/src/components/Metadata/Metadata.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { styled } from "stitches";
 import MetadataItem from "./Item";
 import { NectarMetadata } from "types/nectar";
-import sanitizeAttributes from "services/html-element";
+import { sanitizeAttributes } from "services/html-element";
 
 const StyledMetadata = styled("dl", {});
 

--- a/src/components/RequiredStatement/RequiredStatement.tsx
+++ b/src/components/RequiredStatement/RequiredStatement.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { styled } from "stitches";
 import MetadataItem from "components/Metadata/Item";
 import { NectarRequiredStatement } from "types/nectar";
-import sanitizeAttributes from "services/html-element";
+import { sanitizeAttributes } from "services/html-element";
 
 const StyledRequiredStatement = styled("dl", {});
 

--- a/src/components/SeeAlso/SeeAlso.tsx
+++ b/src/components/SeeAlso/SeeAlso.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { styled } from "stitches";
 import { useGetLabel } from "hooks/useGetLabel";
 import { NectarSeeAlso } from "types/nectar";
-import sanitizeAttributes from "services/html-element";
+import { sanitizeAttributes } from "services/html-element";
 
 const StyledSeeAlso = styled("li", {});
 const StyledWrapper = styled("ul", {});

--- a/src/components/Summary/Summary.test.tsx
+++ b/src/components/Summary/Summary.test.tsx
@@ -16,7 +16,7 @@ describe("summary primitive", () => {
   /**
    * test rendering of html in summary
    */
-  it("Renders 3.0 HTML within a label", async () => {
+  it("Test rendering of html in summary", async () => {
     const { getByRole } = render(<Summary summary={htmlWithinLabel} />);
     const el = getByRole("link");
     expect(el.getAttribute("href")).toBe("https://en.wikipedia.org/wiki/Honey");
@@ -26,7 +26,7 @@ describe("summary primitive", () => {
   /**
    * test sanitization of html in summary
    */
-  it("Renders 3.0 HTML within markup", async () => {
+  it("Test sanitization of html in summary", async () => {
     const { getByText } = render(
       <Summary summary={disallowedHtmlWithinLabel} />
     );

--- a/src/components/Summary/Summary.test.tsx
+++ b/src/components/Summary/Summary.test.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import Summary from "./Summary";
+
+const htmlWithinLabel = {
+  none: [
+    `<a href="https://en.wikipedia.org/wiki/Honey"><strong>&mdash;Honey&mdash;</strong></a>`,
+  ],
+};
+
+const disallowedHtmlWithinLabel = {
+  none: [`<div style="color: gold;">the color of honey</a>`],
+};
+
+describe("summary primitive", () => {
+  /**
+   * test rendering of html in summary
+   */
+  it("Renders 3.0 HTML within a label", async () => {
+    const { getByRole } = render(<Summary summary={htmlWithinLabel} />);
+    const el = getByRole("link");
+    expect(el.getAttribute("href")).toBe("https://en.wikipedia.org/wiki/Honey");
+    expect(el).toContainHTML("<strong>—Honey—</strong>");
+  });
+
+  /**
+   * test sanitization of html in summary
+   */
+  it("Renders 3.0 HTML within markup", async () => {
+    const { getByText } = render(
+      <Summary summary={disallowedHtmlWithinLabel} />
+    );
+    const el = getByText("the color of honey");
+    expect(el).toContainHTML("the color of honey");
+  });
+});

--- a/src/components/Summary/Summary.tsx
+++ b/src/components/Summary/Summary.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Label from "components/Label/Label";
 import { NectarSummary } from "types/nectar";
-import sanitizeAttributes from "services/html-element";
+import { sanitizeAttributes } from "services/html-element";
 
 const Summary: React.FC<NectarSummary> = (props) => {
   const { as, summary } = props;

--- a/src/components/Summary/Summary.tsx
+++ b/src/components/Summary/Summary.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import Label from "components/Label/Label";
 import { NectarSummary } from "types/nectar";
 import { sanitizeAttributes } from "services/html-element";
+import Markup from "components/Markup/Markup";
 
 const Summary: React.FC<NectarSummary> = (props) => {
   const { as, summary } = props;
@@ -12,7 +12,7 @@ const Summary: React.FC<NectarSummary> = (props) => {
   const remove = ["as", "summary"];
   let attributes = sanitizeAttributes(props, remove);
 
-  return <Label as={as} label={summary} {...attributes} />;
+  return <Markup as={as} markup={summary} {...attributes} />;
 };
 
 export default Summary;

--- a/src/components/Thumbnail/Thumbnail.tsx
+++ b/src/components/Thumbnail/Thumbnail.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { NectarExternalWebResource, NectarThumbnail } from "types/nectar";
-import sanitizeAttributes from "services/html-element";
+import { sanitizeAttributes } from "services/html-element";
 import ContentResource from "components/ContentResource/ContentResources";
 
 const Thumbnail: React.FC<NectarThumbnail> = (props) => {

--- a/src/components/Value/Value.tsx
+++ b/src/components/Value/Value.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import Label from "components/Label/Label";
 import { NectarValue } from "types/nectar";
+import Markup from "components/Markup/Markup";
 
 const Value: React.FC<NectarValue> = ({ as = "dd", lang, value }) => (
-  <Label label={value} as={as} lang={lang} />
+  <Markup markup={value} as={as} lang={lang} />
 );
 
 export default Value;

--- a/src/services/html-element.ts
+++ b/src/services/html-element.ts
@@ -1,3 +1,9 @@
+import DOMPurify from "dompurify";
+
+function createMarkup(html: string) {
+  return { __html: sanitizeHTML(html) };
+}
+
 function sanitizeAttributes(props: any, remove: string[]) {
   const entries = Object.keys(props).filter((key) =>
     !remove.includes(key) ? key : null
@@ -11,4 +17,10 @@ function sanitizeAttributes(props: any, remove: string[]) {
   return attributes as React.HTMLAttributes<HTMLElement>;
 }
 
-export default sanitizeAttributes;
+function sanitizeHTML(html: string) {
+  return DOMPurify.sanitize(html, {
+    ALLOWED_TAGS: ["b", "i", "strong", "em", "a"],
+  });
+}
+
+export { createMarkup, sanitizeAttributes, sanitizeHTML };

--- a/src/services/html-element.ts
+++ b/src/services/html-element.ts
@@ -19,6 +19,7 @@ function sanitizeAttributes(props: any, remove: string[]) {
 
 function sanitizeHTML(html: string) {
   return DOMPurify.sanitize(html, {
+    ALLOWED_ATTR: ["href", "src", "alt"],
     ALLOWED_TAGS: [
       "a",
       "b",
@@ -33,7 +34,6 @@ function sanitizeHTML(html: string) {
       "sub",
       "sup",
     ],
-    ALLOWED_ATTR: ["href", "src", "alt"],
     ALLOW_UNKNOWN_PROTOCOLS: false,
   });
 }

--- a/src/services/html-element.ts
+++ b/src/services/html-element.ts
@@ -19,7 +19,22 @@ function sanitizeAttributes(props: any, remove: string[]) {
 
 function sanitizeHTML(html: string) {
   return DOMPurify.sanitize(html, {
-    ALLOWED_TAGS: ["b", "i", "strong", "em", "a"],
+    ALLOWED_TAGS: [
+      "a",
+      "b",
+      "br",
+      "em",
+      "i",
+      "img",
+      "p",
+      "small",
+      "span",
+      "strong",
+      "sub",
+      "sup",
+    ],
+    ALLOWED_ATTR: ["href", "src", "alt"],
+    ALLOW_UNKNOWN_PROTOCOLS: false,
   });
 }
 

--- a/src/types/nectar.ts
+++ b/src/types/nectar.ts
@@ -50,6 +50,11 @@ export interface NectarLabel extends NectarPrimitive {
   label: InternationalString;
 }
 
+export interface NectarMarkup extends NectarPrimitive {
+  as?: "span" | "p" | "label" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "dd";
+  markup?: InternationalString;
+}
+
 export interface NectarMetadata extends NectarPrimitive {
   as?: "dl";
   metadata: MetadataItem[];
@@ -69,6 +74,7 @@ export interface NectarSummary extends NectarPrimitive {
   as?: "span" | "p" | "label" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   summary: InternationalString;
 }
+
 export interface NectarThumbnail extends NectarPrimitive {
   altAsLabel?: InternationalString;
   thumbnail: IIIFExternalWebResource[];


### PR DESCRIPTION
## What does this do?
This adds support for rendering HTML markup that exists within IIIF presentation 3.0 API summary and metadata value entries. Rendering is completed in react via https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml and sanitization of the HTML is completed through https://github.com/cure53/DOMPurify.

Sanitization of HTML will weed out tags and attributes not described in https://iiif.io/api/presentation/3.0/#45-html-markup-in-property-values. I did (and perhaps this is my opinion) allow `<strong>` and `<em>` as well. This might be frowned upon and I'm happy to remove if we should. 