### PR TITLE
Revert to absolute paths

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,5 +1,3 @@
-// Reference: https://github.com/souporserious/bundling-typescript-with-esbuild-for-npm
-
 const { build } = require("esbuild");
 const { dependencies } = require("./package.json");
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "npm run clean && node build.js&& tsc --emitDeclarationOnly --outDir dist && rm -rf dist/tsconfig.tsbuildinfo dist/index.cjs.js.map dist/index.esm.js.map",
+    "build": "npm run clean && node build.js&& tsc --emitDeclarationOnly",
     "build:static": "NODE_ENV=static OUT_DIR=static node build-static.js",
     "clean": "rimraf dist",
     "dev": "NODE_ENV=development node serve.js",
@@ -20,14 +20,14 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mathewjordan/nectar-iiif.git"
+    "url": "git+https://github.com/samvera-labs/nectar-iiif.git"
   },
   "author": "Northwestern University Libraries",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mathewjordan/nectar-iiif/issues"
+    "url": "https://github.com/samvera-labs/nectar-iiif.git/issues"
   },
-  "homepage": "https://github.com/mathewjordan/nectar-iiif#readme",
+  "homepage": "https://github.com/samvera-labs/nectar-iiif.git#readme",
   "devDependencies": {
     "@iiif/presentation-3": "^1.0.4",
     "@iiif/vault": "^0.9.17",

--- a/src/components/ContentResource/ContentResources.tsx
+++ b/src/components/ContentResource/ContentResources.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useRef } from "react";
-import { styled } from "stitches";
+import { styled } from "../../stitches";
 import Hls from "hls.js";
-import { useGetImageResource } from "hooks/useGetImageResource";
-import { sanitizeAttributes } from "services/html-element";
-import { useGetLabel } from "hooks/useGetLabel";
-import { NectarContentResource } from "types/nectar";
+import { useGetImageResource } from "../../hooks/useGetImageResource";
+import { sanitizeAttributes } from "../../services/html-element";
+import { useGetLabel } from "../../hooks/useGetLabel";
+import { NectarContentResource } from "../../types/nectar";
 
 const StyledResource = styled("img", { objectFit: "cover" });
 

--- a/src/components/Homepage/Homepage.tsx
+++ b/src/components/Homepage/Homepage.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { styled } from "stitches";
-import { useGetLabel } from "hooks/useGetLabel";
-import { NectarHomepage } from "types/nectar";
-import { sanitizeAttributes } from "services/html-element";
+import { styled } from "../../stitches";
+import { useGetLabel } from "../../hooks/useGetLabel";
+import { NectarHomepage } from "../../types/nectar";
+import { sanitizeAttributes } from "../../services/html-element";
 
 const StyledHomepage = styled("a", {});
 

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { styled } from "stitches";
-import { useGetLabel } from "hooks/useGetLabel";
-import { NectarLabel } from "types/nectar";
-import { sanitizeAttributes } from "services/html-element";
+import { styled } from "../../stitches";
+import { useGetLabel } from "../../hooks/useGetLabel";
+import { NectarLabel } from "../../types/nectar";
+import { sanitizeAttributes } from "../../services/html-element";
 
 const StyledLabel = styled("span", {});
 

--- a/src/components/Markup/Markup.tsx
+++ b/src/components/Markup/Markup.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { styled } from "stitches";
-import { useGetLabel } from "hooks/useGetLabel";
-import { NectarMarkup } from "types/nectar";
-import { createMarkup, sanitizeAttributes } from "services/html-element";
+import { styled } from "../../stitches";
+import { useGetLabel } from "../../hooks/useGetLabel";
+import { NectarMarkup } from "../../types/nectar";
+import { createMarkup, sanitizeAttributes } from "../../services/html-element";
 
 const StyledMarkup = styled("span", {});
 

--- a/src/components/Metadata/Item.tsx
+++ b/src/components/Metadata/Item.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import Label from "components/Label/Label";
-import Value from "components/Value/Value";
-import { NectarMetadataItem } from "types/nectar";
+import Label from "../../components/Label/Label";
+import Value from "../../components/Value/Value";
+import { NectarMetadataItem } from "../../types/nectar";
 
 const MetadataItem: React.FC<NectarMetadataItem> = (props) => {
   const { item, lang } = props;

--- a/src/components/Metadata/Metadata.tsx
+++ b/src/components/Metadata/Metadata.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { styled } from "stitches";
+import { styled } from "../../stitches";
 import MetadataItem from "./Item";
-import { NectarMetadata } from "types/nectar";
-import { sanitizeAttributes } from "services/html-element";
+import { NectarMetadata } from "../../types/nectar";
+import { sanitizeAttributes } from "../../services/html-element";
 
 const StyledMetadata = styled("dl", {});
 

--- a/src/components/RequiredStatement/RequiredStatement.tsx
+++ b/src/components/RequiredStatement/RequiredStatement.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { styled } from "stitches";
-import MetadataItem from "components/Metadata/Item";
-import { NectarRequiredStatement } from "types/nectar";
-import { sanitizeAttributes } from "services/html-element";
+import { styled } from "../../stitches";
+import MetadataItem from "../../components/Metadata/Item";
+import { NectarRequiredStatement } from "../../types/nectar";
+import { sanitizeAttributes } from "../../services/html-element";
 
 const StyledRequiredStatement = styled("dl", {});
 

--- a/src/components/SeeAlso/SeeAlso.tsx
+++ b/src/components/SeeAlso/SeeAlso.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { styled } from "stitches";
-import { useGetLabel } from "hooks/useGetLabel";
-import { NectarSeeAlso } from "types/nectar";
-import { sanitizeAttributes } from "services/html-element";
+import { styled } from "../../stitches";
+import { useGetLabel } from "../../hooks/useGetLabel";
+import { NectarSeeAlso } from "../../types/nectar";
+import { sanitizeAttributes } from "../../services/html-element";
 
 const StyledSeeAlso = styled("li", {});
 const StyledWrapper = styled("ul", {});

--- a/src/components/Summary/Summary.tsx
+++ b/src/components/Summary/Summary.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { NectarSummary } from "types/nectar";
-import { sanitizeAttributes } from "services/html-element";
-import Markup from "components/Markup/Markup";
+import { NectarSummary } from "../../types/nectar";
+import { sanitizeAttributes } from "../../services/html-element";
+import Markup from "../../components/Markup/Markup";
 
 const Summary: React.FC<NectarSummary> = (props) => {
   const { as, summary } = props;

--- a/src/components/Thumbnail/Thumbnail.tsx
+++ b/src/components/Thumbnail/Thumbnail.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { NectarExternalWebResource, NectarThumbnail } from "types/nectar";
-import { sanitizeAttributes } from "services/html-element";
-import ContentResource from "components/ContentResource/ContentResources";
+import { NectarExternalWebResource, NectarThumbnail } from "../../types/nectar";
+import { sanitizeAttributes } from "../../services/html-element";
+import ContentResource from "../../components/ContentResource/ContentResources";
 
 const Thumbnail: React.FC<NectarThumbnail> = (props) => {
   const { thumbnail } = props;

--- a/src/components/Value/Value.tsx
+++ b/src/components/Value/Value.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { NectarValue } from "types/nectar";
-import Markup from "components/Markup/Markup";
+import { NectarValue } from "../../types/nectar";
+import Markup from "../../components/Markup/Markup";
 
 const Value: React.FC<NectarValue> = ({ as = "dd", lang, value }) => (
   <Markup markup={value} as={as} lang={lang} />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,11 @@
-import Homepage from "components/Homepage/Homepage";
-import Label from "components/Label/Label";
-import Metadata from "components/Metadata/Metadata";
-import RequiredStatement from "components/RequiredStatement/RequiredStatement";
-import SeeAlso from "components/SeeAlso/SeeAlso";
-import Summary from "components/Summary/Summary";
-import Thumbnail from "components/Thumbnail/Thumbnail";
-import Value from "components/Value/Value";
+import Homepage from "./components/Homepage/Homepage";
+import Label from "./components/Label/Label";
+import Metadata from "./components/Metadata/Metadata";
+import RequiredStatement from "./components/RequiredStatement/RequiredStatement";
+import SeeAlso from "./components/SeeAlso/SeeAlso";
+import Summary from "./components/Summary/Summary";
+import Thumbnail from "./components/Thumbnail/Thumbnail";
+import Value from "./components/Value/Value";
 
 export {
   Homepage,

--- a/src/services/html-element.test.ts
+++ b/src/services/html-element.test.ts
@@ -1,4 +1,4 @@
-import { sanitizeHTML } from "services/html-element";
+import { sanitizeHTML } from "./html-element";
 
 describe("sanitizeHTML method", () => {
   it("allows http protocols.", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowJs": true, // Allow JavaScript files to be compiled
     "allowSyntheticDefaultImports": true, // Allow default imports from modules with no default export
-    "baseUrl": "src",
+    "baseUrl": ".",
     "declaration": true, // Generate corresponding .d.ts file
     "esModuleInterop": true, // Disables namespace imports (import * as fs from "fs") and enables CJS/AMD/UMD style imports (import fs from "fs")
     "forceConsistentCasingInFileNames": true, // Disallow inconsistently-cased references to the same file.


### PR DESCRIPTION
@mathewjordan I tried everything under the sun except a non `tsc` bundler to get relative import paths to work, but no dice.  This is a painful commit to make, but at least in the best interest of consuming apps for the time being.

