### PR TITLE
Add custom value scenarios for Metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,56 @@ return (
 
 ### Metadata
 
+Metadata is rendered am HTML `dl` with corresponding `dt` and `dd` elements for they respective `label` and `value` pairs. By default `value` entries are rendered as a string, with `, ` interspersed to seperate multiple entries. A consuming application using can optionally update the `value` output for each entry.
+
+#### Reference
+
+| Prop                 | Type                                                       | Default | Required |
+| -------------------- | ---------------------------------------------------------- | ------- | -------- |
+| `as`                 | `dl`                                                       | `dl`    |          |
+| `metadata`           | [metadata](https://iiif.io/api/presentation/3.0/#metadata) | --      | **Yes**  |
+| `customValueContent` | NectarCustomValueContent[]                                 | --      | --       |
+
 ```jsx
 import { Metadata } from "@samvera/nectar-iiif";
 ```
 
 ```jsx
 return <Metadata metadata={manifest.metadata} />;
+```
+
+#### Custom Value Content
+
+If a consumign application required rendering specific `metadata` item `values` in a custom pattern, the `customValueContent` prop can be set for the `<Metadata>` component. The pattern requires `matchingLabel` as following https://iiif.io/api/presentation/3.0/#label and `Content` asa ReactElement carrying `props`. The element set for `Content` must map `props.value` to the appropriate code in the custom pattern.
+
+In the example below, the value of **Pantaloon** with a matching `label` of `{ none: ["Subject"] }` would be rendered as `<dd><a href="https://example.org/?subject=Pantaloon">Pantaloon</a><dd>`, while the `value` entry of **comic masks** would render simply as `<dd>comic masks</dd>`.
+
+```jsx
+const metadata = [
+  {
+    label: { none: ["Genre"] },
+    value: { none: ["comic masks"] },
+  },
+  {
+    label: { none: ["Subject"] },
+    value: { none: ["Pantaloon"] },
+  },
+];
+
+const CustomValueSubject = (props) => (
+  <a href={encodeURI(`https://example.org/?subject=${props.value}`)}>
+    {props.value}
+  </a>
+);
+
+const customValueContent = [
+  {
+    matchingLabel: { none: ["Subject"] },
+    Content: <CustomValueSubject />,
+  },
+];
+
+return <Metadata metadata={metadata} customValueContent={customValueContent} />;
 ```
 
 ---

--- a/src/components/ContentResource/ContentResources.tsx
+++ b/src/components/ContentResource/ContentResources.tsx
@@ -3,7 +3,7 @@ import { styled } from "../../stitches";
 import Hls from "hls.js";
 import { useGetImageResource } from "../../hooks/useGetImageResource";
 import { sanitizeAttributes } from "../../services/html-element";
-import { useGetLabel } from "../../hooks/useGetLabel";
+import { getLabelAsString } from "../../services/label-helpers";
 import { NectarContentResource } from "../../types/nectar";
 
 const StyledResource = styled("img", { objectFit: "cover" });
@@ -13,7 +13,7 @@ const ContentResource: React.FC<NectarContentResource> = (props) => {
   const { contentResource, altAsLabel, region = "full" } = props;
 
   let alt: string | undefined;
-  if (altAsLabel) alt = useGetLabel(altAsLabel) as string;
+  if (altAsLabel) alt = getLabelAsString(altAsLabel) as string;
 
   /**
    * Create attributes and remove React props

--- a/src/components/Homepage/Homepage.tsx
+++ b/src/components/Homepage/Homepage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { styled } from "../../stitches";
-import { useGetLabel } from "../../hooks/useGetLabel";
+import { getLabelAsString } from "../../services/label-helpers";
 import { NectarHomepage } from "../../types/nectar";
 import { sanitizeAttributes } from "../../services/html-element";
 
@@ -19,7 +19,10 @@ const Homepage: React.FC<NectarHomepage> = (props) => {
     <>
       {homepage &&
         homepage.map((resource) => {
-          const label = useGetLabel(resource.label, attributes.lang) as string;
+          const label = getLabelAsString(
+            resource.label,
+            attributes.lang
+          ) as string;
           return (
             <StyledHomepage
               aria-label={children ? label : undefined}

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { styled } from "../../stitches";
-import { useGetLabel } from "../../hooks/useGetLabel";
+import { getLabelAsString } from "../../services/label-helpers";
 import { NectarLabel } from "../../types/nectar";
 import { sanitizeAttributes } from "../../services/html-element";
 
@@ -17,7 +17,7 @@ const Label: React.FC<NectarLabel> = (props) => {
 
   return (
     <StyledLabel as={as} {...attributes}>
-      {useGetLabel(label, attributes.lang as string) as string}
+      {getLabelAsString(label, attributes.lang as string) as string}
     </StyledLabel>
   );
 };

--- a/src/components/Markup/Markup.tsx
+++ b/src/components/Markup/Markup.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { styled } from "../../stitches";
-import { useGetLabel } from "../../hooks/useGetLabel";
+import { getLabelAsString } from "../../services/label-helpers";
 import { NectarMarkup } from "../../types/nectar";
 import { createMarkup, sanitizeAttributes } from "../../services/html-element";
 
@@ -18,7 +18,7 @@ const Markup: React.FC<NectarMarkup> = (props) => {
   let attributes = sanitizeAttributes(props, remove);
 
   const html = createMarkup(
-    useGetLabel(markup, attributes.lang as string) as string
+    getLabelAsString(markup, attributes.lang as string) as string
   );
 
   return (

--- a/src/components/Metadata/Item.test.tsx
+++ b/src/components/Metadata/Item.test.tsx
@@ -1,13 +1,12 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import Item from "./Item";
+import { customValueContent } from "../../fixtures/custom";
 
 const htmlWithinMetadataItem = {
   label: { none: ["Type"] },
   value: {
-    none: [
-      `<a href="https://en.wikipedia.org/wiki/Honey"><b>Honey</b></a>`,
-    ],
+    none: [`<a href="https://en.wikipedia.org/wiki/Honey"><b>Honey</b></a>`],
   },
 };
 
@@ -22,9 +21,16 @@ const strongWithinMetadataItem = {
 
 const htmlWithinLabel = {
   label: {
-    none: [
-      `<a href="https://en.wikipedia.org/wiki/Type"><b>Type</b></a>`,
-    ],
+    none: [`<a href="https://en.wikipedia.org/wiki/Type"><b>Type</b></a>`],
+  },
+  value: {
+    none: [`Honey`],
+  },
+};
+
+const itemForCustomValue = {
+  label: {
+    none: [`Subject`],
   },
   value: {
     none: [`Honey`],
@@ -59,5 +65,21 @@ describe("metadata primitive (item)", () => {
     render(<Item item={htmlWithinLabel} />);
     const el = screen.queryByText("Type");
     expect(el).toBeNull;
+  });
+
+  /**
+   * Test passing customValueContent
+   */
+  it("Test passing customValueContent", () => {
+    render(
+      <Item
+        item={itemForCustomValue}
+        customValueContent={customValueContent[1].Content}
+      />
+    );
+    const el = screen.queryByRole("link");
+    expect(el).toContainHTML(
+      '<a href="https://example.org/?subject=Honey">Honey</a>'
+    );
   });
 });

--- a/src/components/Metadata/Item.tsx
+++ b/src/components/Metadata/Item.tsx
@@ -2,14 +2,25 @@ import React from "react";
 import Label from "../../components/Label/Label";
 import Value from "../../components/Value/Value";
 import { NectarMetadataItem } from "../../types/nectar";
+import CustomValue from "../Value/CustomValue";
 
 const MetadataItem: React.FC<NectarMetadataItem> = (props) => {
-  const { item, lang } = props;
+  const { item, lang, customValueContent } = props;
   const { label, value } = item;
+
   return (
     <div role="group">
       <Label as="dt" label={label} lang={lang} />
-      <Value as="dd" value={value} lang={lang} />
+      {customValueContent ? (
+        <CustomValue
+          as="dd"
+          customValueContent={customValueContent}
+          value={value}
+          lang={lang}
+        />
+      ) : (
+        <Value as="dd" value={value} lang={lang} />
+      )}
     </div>
   );
 };

--- a/src/components/Metadata/Metadata.tsx
+++ b/src/components/Metadata/Metadata.tsx
@@ -2,19 +2,20 @@ import React from "react";
 import { styled } from "../../stitches";
 import MetadataItem from "./Item";
 import { NectarMetadata } from "../../types/nectar";
+import { parseCustomContent } from "../../services/custom";
 import { sanitizeAttributes } from "../../services/html-element";
 
 const StyledMetadata = styled("dl", {});
 
 const Metadata: React.FC<NectarMetadata> = (props) => {
-  const { as, metadata } = props;
+  const { as, customValueContent, metadata } = props;
 
   if (!Array.isArray(metadata)) return <></>;
 
   /**
    * Create attributes and remove React props
    */
-  const remove = ["as", "metadata"];
+  const remove = ["as", "customValueContent", "metadata"];
   let attributes = sanitizeAttributes(props, remove);
 
   return (
@@ -22,8 +23,17 @@ const Metadata: React.FC<NectarMetadata> = (props) => {
       {metadata.length > 0 && (
         <StyledMetadata as={as} {...attributes}>
           {metadata.map((item, index) => {
+            const customValue = customValueContent
+              ? parseCustomContent(item.label, customValueContent)
+              : undefined;
+
             return (
-              <MetadataItem item={item} key={index} lang={attributes.lang} />
+              <MetadataItem
+                customValueContent={customValue}
+                item={item}
+                key={index}
+                lang={attributes?.lang}
+              />
             );
           })}
         </StyledMetadata>

--- a/src/components/PartOf/PartOf.tsx
+++ b/src/components/PartOf/PartOf.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { styled } from "../../stitches";
-import { useGetLabel } from "../../hooks/useGetLabel";
+import { getLabelAsString } from "../../services/label-helpers";
 import { NectarPartOf } from "../../types/nectar";
 import { sanitizeAttributes } from "../../services/html-element";
 
@@ -21,7 +21,7 @@ const PartOf: React.FC<NectarPartOf> = (props) => {
       {partOf &&
         partOf.map((resource) => {
           const label = resource.label
-            ? (useGetLabel(resource.label, attributes.lang) as string)
+            ? (getLabelAsString(resource.label, attributes.lang) as string)
             : undefined;
           return (
             <StyledPartOf key={resource.id}>

--- a/src/components/SeeAlso/SeeAlso.tsx
+++ b/src/components/SeeAlso/SeeAlso.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { styled } from "../../stitches";
-import { useGetLabel } from "../../hooks/useGetLabel";
+import { getLabelAsString } from "../../services/label-helpers";
 import { NectarSeeAlso } from "../../types/nectar";
 import { sanitizeAttributes } from "../../services/html-element";
 
@@ -20,7 +20,10 @@ const SeeAlso: React.FC<NectarSeeAlso> = (props) => {
     <StyledWrapper as={as}>
       {seeAlso &&
         seeAlso.map((resource) => {
-          const label = useGetLabel(resource.label, attributes.lang) as string;
+          const label = getLabelAsString(
+            resource.label,
+            attributes.lang
+          ) as string;
           return (
             <StyledSeeAlso key={resource.id}>
               <a href={resource.id} {...attributes}>

--- a/src/components/Value/CustomValue.test.tsx
+++ b/src/components/Value/CustomValue.test.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import CustomValue from "./CustomValue";
+import { CustomValueSubject } from "../../fixtures/custom";
+
+const value = {
+  none: [`Honey`, "Bee"],
+};
+
+describe("metadata (CustomValue)", () => {
+  it("Test rendering of html in metadata value", () => {
+    const { getAllByRole } = render(
+      <CustomValue value={value} customValueContent={<CustomValueSubject />} />
+    );
+
+    const links = getAllByRole("link");
+    links.forEach((element, i) => {
+      expect(element.getAttribute("href")).toBe(
+        `https://example.org/?subject=${value.none[i]}`
+      );
+      expect(element).toHaveTextContent(value.none[i]);
+    });
+  });
+});

--- a/src/components/Value/CustomValue.tsx
+++ b/src/components/Value/CustomValue.tsx
@@ -1,0 +1,30 @@
+import React, { cloneElement, Fragment } from "react";
+import { NectarCustomValue } from "../../types/nectar";
+import { styled } from "../../stitches";
+import { getLabelEntries } from "../../services/label-helpers";
+
+const StyledCustomValue = styled("span", {});
+
+const CustomValue: React.FC<NectarCustomValue> = ({
+  as = "dd",
+  customValueContent,
+  lang,
+  value,
+}) => {
+  const entries = getLabelEntries(value, lang)?.map((entry) => {
+    return cloneElement(customValueContent, {
+      value: entry,
+    });
+  });
+
+  return (
+    <StyledCustomValue as={as} lang={lang}>
+      {entries?.map((entry, index) => [
+        index > 0 && ", ",
+        <Fragment key={index}>{entry}</Fragment>,
+      ])}
+    </StyledCustomValue>
+  );
+};
+
+export default CustomValue;

--- a/src/dev.tsx
+++ b/src/dev.tsx
@@ -14,16 +14,21 @@ import {
 } from "./index";
 import DynamicUrl from "./dev/DynamicUrl";
 import { manifests } from "./dev/manifests";
+import {
+  NectarCustomValueContent,
+  NectarExternalWebResource,
+  NectarIIIFResource,
+} from "./types/nectar";
 
 const Wrapper = () => {
   const defaultUrl: string = manifests[0].url;
-  const [partOf, setPartOf] = useState();
-  const [seeAlso, setSeeAlso] = useState();
+  const [partOf, setPartOf] = useState<NectarIIIFResource[]>();
+  const [seeAlso, setSeeAlso] = useState<NectarExternalWebResource[]>();
   const [thumbnail, setThumbnail] = useState();
-  const [homepage, setHomepage] = useState();
+  const [homepage, setHomepage] = useState<NectarExternalWebResource[]>();
   const [manifest, setManifest] = useState<ManifestNormalized>();
-  const [lang, setLanguage] = useState<String | undefined>();
-  const [url, setUrl] = React.useState(defaultUrl);
+  const [lang, setLanguage] = useState<string | undefined>();
+  const [url, setUrl] = useState(defaultUrl);
 
   useEffect(() => {
     const vault = new Vault();
@@ -49,17 +54,47 @@ const Wrapper = () => {
 
   const { label, metadata, requiredStatement, summary } = manifest;
 
+  const CustomValueDepartment = (props) => (
+    <a href={encodeURI(`https://example.org/department/${props.value}`)}>
+      <strong>{props.value}</strong>
+    </a>
+  );
+
+  const CustomValueSubject = (props) => (
+    <a href={encodeURI(`https://example.org/?subject=${props.value}`)}>
+      {props.value}
+    </a>
+  );
+
+  const customValueContent: NectarCustomValueContent[] = [
+    {
+      matchingLabel: { en: ["Subject"] },
+      Content: <CustomValueSubject />,
+    },
+  ];
+
   return (
     <>
       <div>
-        <Label as="h3" label={label} lang={lang} />
-        <Homepage homepage={homepage}>More Details</Homepage>
-        <Summary as="p" summary={summary} lang={lang} />
-        <Metadata metadata={metadata} lang={lang} />
-        <RequiredStatement requiredStatement={requiredStatement} lang={lang} />
-        {thumbnail && <Thumbnail thumbnail={thumbnail} alt="random" />}
-        <PartOf partOf={partOf} />
-        <SeeAlso seeAlso={seeAlso} />
+        {label && <Label as="h3" label={label} lang={lang} />}
+        {homepage && <Homepage homepage={homepage}>More Details</Homepage>}
+        {summary && <Summary as="p" summary={summary} lang={lang} />}
+        {metadata && (
+          <Metadata
+            metadata={metadata}
+            customValueContent={customValueContent}
+            lang={lang}
+          />
+        )}
+        {requiredStatement && (
+          <RequiredStatement
+            requiredStatement={requiredStatement}
+            lang={lang}
+          />
+        )}
+        {thumbnail && <Thumbnail thumbnail={thumbnail} />}
+        {partOf && <PartOf partOf={partOf} />}
+        {seeAlso && <SeeAlso seeAlso={seeAlso} />}
       </div>
       <DynamicUrl url={url} setUrl={setUrl} handleLanguage={handleLanguage} />
     </>

--- a/src/dev/manifests.ts
+++ b/src/dev/manifests.ts
@@ -1,27 +1,27 @@
 export const manifests = [
   {
-    url: "https://iiif.harvardartmuseums.org/manifests/object/307976",
-    label: "Milk Pond",
+    url: "https://acw5dcf49d.execute-api.us-east-1.amazonaws.com/dev/items/iiif-image-manifest-1",
+    label: "Pantalone classico",
+  },
+  {
+    url: "https://manifests.collections.yale.edu/ycba/obj/21168",
+    label: "Greenland Falcon",
   },
   {
     url: "https://digital.lib.utk.edu/assemble/manifest/rftaart/7",
     label: "The Wildfires",
   },
   {
+    url: "https://iiif.harvardartmuseums.org/manifests/object/307976",
+    label: "Milk Pond",
+  },
+  {
     url: "https://raw.githubusercontent.com/samvera-labs/nectar-iiif/main/public/fixtures/manifest/the-takeover.json",
     label: "The Takover",
   },
   {
-    url: "https://acw5dcf49d.execute-api.us-east-1.amazonaws.com/dev/items/iiif-image-manifest-1",
-    label: "Pantalone classico",
-  },
-  {
     url: "https://iiif.bodleian.ox.ac.uk/iiif/manifest/e32a277e-91e2-4a6d-8ba6-cc4bad230410.json",
     label: "Bodleian Library MS. Ind. Inst. Misc. 22",
-  },
-  {
-    url: "https://manifests.collections.yale.edu/ycba/obj/21168",
-    label: "Greenland Falcon",
   },
   {
     url: "https://iiif.io/api/cookbook/recipe/0006-text-language/manifest.json",

--- a/src/fixtures/custom.tsx
+++ b/src/fixtures/custom.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { NectarCustomValueContent } from "src/types/nectar";
+
+interface CustomValueWrapperProps {
+  value?: string;
+}
+
+const CustomValueDate: React.FC<CustomValueWrapperProps> = (props) => (
+  <a href={encodeURI(`https://example.org/?date=${props.value}`)}>
+    {props.value}
+  </a>
+);
+
+const CustomValueSubject: React.FC<CustomValueWrapperProps> = (props) => (
+  <a href={encodeURI(`https://example.org/?subject=${props.value}`)}>
+    {props.value}
+  </a>
+);
+
+const customValueContent: NectarCustomValueContent[] = [
+  {
+    matchingLabel: { none: ["Date"] },
+    Content: <CustomValueDate />,
+  },
+  {
+    matchingLabel: { none: ["Subject"] },
+    Content: <CustomValueSubject />,
+  },
+];
+
+export { CustomValueSubject, customValueContent };

--- a/src/services/custom.test.tsx
+++ b/src/services/custom.test.tsx
@@ -1,0 +1,22 @@
+import { render } from "@testing-library/react";
+import { parseCustomContent } from "./custom";
+import { customValueContent } from "../fixtures/custom";
+import { ReactElement } from "react";
+
+const label = { none: ["Subject"] };
+
+describe("parseCustomContent", () => {
+  it("Returns plucked matching Content ", () => {
+    const customValueElement = parseCustomContent(label, customValueContent);
+
+    /**
+     * note that the value is "undefined as `props.value` has yet been
+     * written to th ReactElement in components/Value/CustomValue
+     */
+    const { getByRole } = render(customValueElement as ReactElement);
+    const el = getByRole("link");
+    expect(el).toContainHTML(
+      '<a href="https://example.org/?subject=undefined" />'
+    );
+  });
+});

--- a/src/services/custom.ts
+++ b/src/services/custom.ts
@@ -1,0 +1,22 @@
+import { InternationalString } from "@iiif/presentation-3";
+import { NectarCustomValueContent } from "../types/nectar";
+import { getLabelAsString } from "./label-helpers";
+
+export function parseCustomContent(
+  label: InternationalString,
+  valueArray: NectarCustomValueContent[]
+) {
+  const customContent = valueArray
+    .filter((entry) => {
+      const { matchingLabel } = entry;
+      const lang = Object.keys(entry.matchingLabel)[0];
+      const labelPattern = getLabelAsString(matchingLabel, lang);
+
+      if (getLabelAsString(label, lang) === labelPattern) return true;
+    })
+    .map((entry) => entry.Content);
+
+  if (!Array.isArray(customContent)) return;
+
+  return customContent[0];
+}

--- a/src/services/label-helpers.test.ts
+++ b/src/services/label-helpers.test.ts
@@ -1,0 +1,49 @@
+import { InternationalString } from "@iiif/presentation-3";
+import { getLabelAsString, getLabelEntries } from "./label-helpers";
+
+const singleEntry = { none: ["Subject"] };
+const multipleEntries = { none: ["Honey", "Bee"] };
+const multipleLang = { none: ["Flora"], en: ["Flower"], fr: ["Fleur"] };
+const nonValidLabel = "Raspberry";
+
+describe("getLabelAsString()", () => {
+  it("Returns the string ", () => {
+    const single = getLabelAsString(singleEntry);
+    expect(single).toBe("Subject");
+
+    const multiple = getLabelAsString(multipleEntries);
+    expect(multiple).toBe("Honey, Bee");
+
+    const langString = getLabelAsString(multipleLang, "fr");
+    expect(langString).toBe("Fleur");
+
+    const noneFallback = getLabelAsString(multipleLang);
+    expect(noneFallback).toBe("Flora");
+
+    const nonValid = getLabelAsString(
+      nonValidLabel as unknown as InternationalString
+    );
+    expect(nonValid).toBe("Raspberry");
+  });
+});
+
+describe("getLabelEntries()", () => {
+  it("Returns label entries in an array ", () => {
+    const single = getLabelEntries(singleEntry);
+    expect(single).toStrictEqual(["Subject"]);
+
+    const multiple = getLabelEntries(multipleEntries);
+    expect(multiple).toStrictEqual(["Honey", "Bee"]);
+
+    const langString = getLabelEntries(multipleLang, "fr");
+    expect(langString).toStrictEqual(["Fleur"]);
+
+    const noneFallback = getLabelEntries(multipleLang);
+    expect(noneFallback).toStrictEqual(["Flora"]);
+
+    const nonValid = getLabelEntries(
+      nonValidLabel as unknown as InternationalString
+    );
+    expect(nonValid).toStrictEqual(["Raspberry"]);
+  });
+});

--- a/src/services/label-helpers.ts
+++ b/src/services/label-helpers.ts
@@ -1,6 +1,6 @@
 import { InternationalString } from "@iiif/presentation-3";
 
-export const useGetLabel = (
+export const getLabelEntries = (
   label: InternationalString,
   lang: string = "none"
 ) => {
@@ -20,7 +20,7 @@ export const useGetLabel = (
    */
   if (!label[lang]) {
     const codes: Array<string> = Object.getOwnPropertyNames(label);
-    if (codes.length > 0) return label[codes[0]]?.join(", ");
+    if (codes.length > 0) return label[codes[0]];
   }
 
   /*
@@ -29,7 +29,13 @@ export const useGetLabel = (
   if (!label[lang]) return null;
   if (!Array.isArray(label[lang])) return null;
 
-  const entries = label[lang] as string[];
+  return label[lang] as string[];
+};
 
-  return entries.join(", ");
+export const getLabelAsString = (
+  label: InternationalString,
+  lang: string = "none"
+) => {
+  const entries = getLabelEntries(label, lang);
+  return Array.isArray(entries) ? entries.join(", ") : entries;
 };

--- a/src/types/nectar.ts
+++ b/src/types/nectar.ts
@@ -3,12 +3,18 @@ import {
   InternationalString,
   MetadataItem,
 } from "@iiif/presentation-3";
-import React, { ReactNode } from "react";
+import React, { ReactElement, ReactNode } from "react";
 
 export interface NectarPrimitive extends React.HTMLAttributes<HTMLElement> {}
 
+export interface NectarCustomValueContent {
+  matchingLabel: InternationalString;
+  Content: ReactElement;
+}
+
 export interface NectarMetadataItem extends NectarPrimitive {
   item: MetadataItem;
+  customValueContent?: ReactElement;
 }
 
 export interface NectarContentResource extends NectarPrimitive {
@@ -64,6 +70,7 @@ export interface NectarMarkup extends NectarPrimitive {
 
 export interface NectarMetadata extends NectarPrimitive {
   as?: "dl";
+  customValueContent?: NectarCustomValueContent[];
   metadata: MetadataItem[];
 }
 
@@ -96,4 +103,8 @@ export interface NectarThumbnail extends NectarPrimitive {
 export interface NectarValue extends NectarPrimitive {
   as?: "span" | "dd";
   value: InternationalString;
+}
+
+export interface NectarCustomValue extends NectarValue {
+  customValueContent: ReactElement;
 }


### PR DESCRIPTION
## What does this do?

This work brings forward functionality that allows for a custom wrapping of IIIF metadata value entries through a the optional prop `customValueContent` on `<Metadata>` primitive component.

This is done by checking for a `matchingLabel` pattern as the `<Metadata>` component returns each `<MetadataItem>`. If a match in completed, the value is returned through the `<CustomValue>` component which injects the the `value` as prop into the ReactElement set in the `Content` in `customValueContent` .

In the example below, a Metadata value of **Pantaloon** with a matching label of `{ none: ["Subject"] }` would be rendered as `<a href="https://example.org/?subject=Pantaloon">Pantaloon</a>`, while the value **comic masks** would not.

```tsx
  const metadata = [
    {
      "label": { "none": ["Genre"] },
      "value": { "none": ["comic masks"] }
    },
    {
      "label": { "none": ["Subject"] },
      "value": { "none": ["Pantaloon"] }
    },
  ]

  const CustomValueSubject = (props) => (
    <a href={encodeURI(`https://example.org/?subject=${props.value}`)}>
      {props.value}
    </a>
  );

  const customValueContent: NectarCustomValueContent[] = [
    {
      matchingLabel: { none: ["Subject"] },
      Content: <CustomValueSubject />,
    },
  ];

  return (
          <Metadata
            metadata={metadata}
            customValueContent={customValueContent}
          />
  );
```
