### PR TITLE
Add data-label attribute for Metadata items.

### DIFF
--- a/src/components/Metadata/Item.tsx
+++ b/src/components/Metadata/Item.tsx
@@ -3,13 +3,21 @@ import Label from "../../components/Label/Label";
 import Value from "../../components/Value/Value";
 import { NectarMetadataItem } from "../../types/nectar";
 import CustomValue from "../Value/CustomValue";
+import { getLabelAsString } from "../../services/label-helpers";
 
 const MetadataItem: React.FC<NectarMetadataItem> = (props) => {
   const { item, lang, customValueContent } = props;
   const { label, value } = item;
 
+  /**
+   * Create value for data-label attribute for use as a selector
+   */
+  const dataAttribute = getLabelAsString(label)
+    ?.replace(" ", "-")
+    .toLowerCase();
+
   return (
-    <div role="group">
+    <div role="group" data-label={dataAttribute}>
       <Label as="dt" label={label} lang={lang} />
       {customValueContent ? (
         <CustomValue


### PR DESCRIPTION
## What does this do?

This adds a `data-label` selector to `Metadata` item groups for use as a CSS selector or otherwise. This relates to Northwestern's need to easily customize display of certain Metadata entries.

<img width="619" alt="image" src="https://user-images.githubusercontent.com/7376450/211085726-7df6956c-1fe2-4f72-94c0-12604157f71b.png">

