### PR TITLE
Add thumbnail width and height attributes

### DIFF
--- a/src/components/ContentResource/ContentResources.tsx
+++ b/src/components/ContentResource/ContentResources.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useRef } from "react";
-import { styled } from "../../stitches";
 import Hls from "hls.js";
+import React, { useEffect, useRef } from "react";
 import { useGetImageResource } from "../../hooks/useGetImageResource";
 import { sanitizeAttributes } from "../../services/html-element";
 import { getLabelAsString } from "../../services/label-helpers";
+import { styled } from "../../stitches";
 import { NectarContentResource } from "../../types/nectar";
 
 const StyledResource = styled("img", { objectFit: "cover" });
@@ -124,6 +124,8 @@ const ContentResource: React.FC<NectarContentResource> = (props) => {
           css={{ width: width, height: height }}
           key={id}
           src={src}
+          width={width}
+          height={height}
           {...attributes}
         />
       );

--- a/src/services/html-element.test.ts
+++ b/src/services/html-element.test.ts
@@ -19,11 +19,11 @@ describe("sanitizeHTML method", () => {
     expect(clean).toBe("The color of <i>honey</i>");
   });
 
-  it("allows alt and src while removing width.", () => {
-    const html = `<img src="https://foo.bar/honey.jpg" alt="A jar of honey" width="200">`;
+  it("allows alt, src, width and height while removing anything else.", () => {
+    const html = `<img src="https://foo.bar/honey.jpg" alt="A jar of honey" width="200" height="500" foo="bar">`;
     const clean = sanitizeHTML(html);
     expect(clean).toBe(
-      '<img src="https://foo.bar/honey.jpg" alt="A jar of honey" />'
+      '<img src="https://foo.bar/honey.jpg" alt="A jar of honey" width="200" height="500" />'
     );
   });
 

--- a/src/services/html-element.ts
+++ b/src/services/html-element.ts
@@ -21,7 +21,7 @@ function sanitizeHTML(html: string) {
   return sanitizeHtml(html, {
     allowedAttributes: {
       a: ["href"],
-      img: ["alt", "src"],
+      img: ["alt", "src", "height", "width"],
     },
     allowedSchemes: ["http", "https", "mailto"],
     allowedTags: [


### PR DESCRIPTION
Based on some Lighthouse reports, it suggests explicit `width` and `height` as attributes, in addition to CSS `width` and `height`.